### PR TITLE
Fixed image uploading issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,7 +69,7 @@ class API:
         image_information = self.img_utils.get_image_information(image_file, image_filename)
 
         # Thumbnail data
-        thumbnail_file = self.img_utils.create_thumbnail(image_file, (240, 240), post_id)
+        thumbnail_file = self.img_utils.create_thumbnail(image_file, (240, 240))
         thumbnail_filename = basename(image_filename) + "-thumbnail.png"
         thumbnail_ipfs_hash = self.ipfs_utils.upload_image(thumbnail_file, thumbnail_filename, post_id)
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, request, jsonify, escape
 from flask_cors import CORS
 from utils.ipfs import IPFSUtils
 from utils.images import ImagesUtils
+from os.path import basename
 
 
 class API:
@@ -58,19 +59,20 @@ class API:
         # Check if the user added an image
         if not request.files.getlist("file"):
             return jsonify({})
+
         image_file = request.files["file"]
         post_id = request.form["post_id"]
+
         # Original image data
         image_filename = image_file.filename
-        image_extension = image_filename.split(".")[-1]
-        image_format = image_file.mimetype.split("/")[-1]
-        image_basename = image_filename[:-(len(image_extension) + 1)]  # Plus the dot (.)
         image_ipfs_hash = self.ipfs_utils.upload_image(image_file.read(), image_filename, post_id)
+        image_information = self.img_utils.get_image_information(image_file, image_filename)
+
         # Thumbnail data
-        thumbnail_file = self.img_utils.create_thumbnail(image_file, image_format, (240, 240))
-        thumbnail_filename = image_basename + "-thumbnail.jpg"
+        thumbnail_file = self.img_utils.create_thumbnail(image_file, (240, 240), post_id)
+        thumbnail_filename = basename(image_filename) + "-thumbnail.png"
         thumbnail_ipfs_hash = self.ipfs_utils.upload_image(thumbnail_file, thumbnail_filename, post_id)
-        image_information = self.img_utils.get_image_information(image_file, image_format, image_filename)
+
         response = [
             image_information,
             {

--- a/utils/images.py
+++ b/utils/images.py
@@ -1,8 +1,5 @@
 from PIL import Image
-import ipfsapi
 import io
-import os, hashlib
-
 
 class ImagesUtils:
     @staticmethod

--- a/utils/images.py
+++ b/utils/images.py
@@ -21,14 +21,10 @@ class ImagesUtils:
 
     @staticmethod
     def get_image_information(image, img_filename) -> dict:
+        im = Image.open(image)
         information = {
-            "size": 0,  # Size in Kilobytes
-            "dimensions": None,  # A list [width, height],
+            "size": len(image.read()) / 1024,  # Size in Kilobytes
+            "dimensions": str(im.size[0]) + "x" + str(im.size[1]),  # A list [width, height],
             "filename": img_filename
         }
-        im = Image.open(image)
-        # calculate size of byte buffer in KB
-        information["size"] = len(image.read()) / 1024
-        # dimensions
-        information["dimensions"] = str(im.size[0]) + "x" + str(im.size[1])
         return information

--- a/utils/images.py
+++ b/utils/images.py
@@ -6,7 +6,7 @@ import os, hashlib
 
 class ImagesUtils:
     @staticmethod
-    def create_thumbnail(image, size: tuple, post_id: str) -> bytes:
+    def create_thumbnail(image, size: tuple) -> bytes:
     
         # storage for thumbnail bytes
         bytes_thmb = io.BytesIO() 

--- a/utils/images.py
+++ b/utils/images.py
@@ -1,50 +1,34 @@
 from PIL import Image
-
+import ipfsapi
 import io
-import os
+import os, hashlib
 
 
 class ImagesUtils:
     @staticmethod
-    def create_thumbnail(image, img_format: str, size: tuple) -> bytes:
-        # This problem happens only when openning .JPG files
-        try:
-            im = Image.open(image).convert("RGB")
-        except IOError:
-            im = Image.open(image)
-        bytes_img = io.BytesIO()
-        # Saves image bytes into bytes_img buffer
-        # Use PNG as default thumbnail type, REQUIRED to preserve transparency
-        if im.format == "GIF":
-            # FIXME: PIL works poorly with transparent gifs. fix this at a later date
-            # Gather palette info of first frame of GIF
-            im.putpalette(im.getpalette())
-            # Create a new image with this palette, save it as PNG
-            new_im = Image.new("RGBA", im.size)
-            new_im.paste(im)
-            new_im.thumbnail(size)
-            new_im.save(bytes_img, format="PNG")
-        else:
-            im.thumbnail(size)
-            # TODO: Replace img_format with im.format ? What if a file has no extension?
-            im.save(bytes_img, format="PNG")
+    def create_thumbnail(image, size: tuple, post_id: str) -> bytes:
+    
+        # storage for thumbnail bytes
+        bytes_thmb = io.BytesIO() 
+        
+        # change the size, save it as a png
+        thumb_im = Image.open(image)
+        thumb_im.thumbnail(size)
+        thumb_im.save(bytes_thmb, format="PNG")
 
-        return bytes_img.getvalue()
+        # return raw thumbnail bytes
+        return bytes_thmb.getvalue()
 
     @staticmethod
-    def get_image_information(image, img_format, img_filename) -> dict:
+    def get_image_information(image, img_filename) -> dict:
         information = {
             "size": 0,  # Size in Kilobytes
             "dimensions": None,  # A list [width, height],
             "filename": img_filename
         }
-        try:
-            im = Image.open(image).convert("RGB")
-        except IOError:
-            im = Image.open(image)
-        img_bytes = io.BytesIO()
-        im.save(img_bytes, img_format)
-        img_bytes.seek(0, os.SEEK_END)
-        information["size"] = img_bytes.tell() / 1024
+        im = Image.open(image)
+        # calculate size of byte buffer in KB
+        information["size"] = len(image.read()) / 1024
+        # dimensions
         information["dimensions"] = str(im.size[0]) + "x" + str(im.size[1])
         return information

--- a/utils/ipfs.py
+++ b/utils/ipfs.py
@@ -65,6 +65,7 @@ class IPFSUtils:
             ipfs.files_mkdir(images_dir)
         except StatusError:
             pass
+
         img_location = images_dir + filename
         # Add the file to the MFS
         ipfs.files_write(img_location, io.BytesIO(image), create=True)

--- a/utils/ipfs.py
+++ b/utils/ipfs.py
@@ -65,7 +65,6 @@ class IPFSUtils:
             ipfs.files_mkdir(images_dir)
         except StatusError:
             pass
-
         img_location = images_dir + filename
         # Add the file to the MFS
         ipfs.files_write(img_location, io.BytesIO(image), create=True)


### PR DESCRIPTION
Fixed transparent gif issue when uploading images. 

Slightly simplified upload code.

To decide still: Use 1024B or 1000B size for a KB. [(see kibibyte vs kilobyte table)](https://stackoverflow.com/questions/19819763/really-1-kb-kilobyte-equals-1024-bytes). Currently kibibyte is in use.